### PR TITLE
NGC-1986: Ensure push-notification-scheduler supports locking

### DIFF
--- a/app/uk/gov/hmrc/pushnotificationscheduler/config/GuiceModule.scala
+++ b/app/uk/gov/hmrc/pushnotificationscheduler/config/GuiceModule.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pushnotificationscheduler.config
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names.named
 import play.api.Mode.Mode
-import play.api.{Configuration, Environment}
+import play.api.{Configuration, Environment, Logger}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http.{HttpDelete, HttpGet, HttpPost}
@@ -39,6 +39,8 @@ class GuiceModule(environment: Environment, configuration: Configuration) extend
     bind(classOf[HttpPost]).to(classOf[WSHttp])
     bind(classOf[HttpDelete]).to(classOf[WSHttp])
     bind(classOf[AuditConnector]).to(classOf[MicroserviceAuditConnector])
+
+    bind(classOf[Logger]).toInstance(Logger("push-notification-scheduler"))
 
     bind(classOf[String]).annotatedWith(named("pushRegistrationUrl")).toInstance(baseUrl("push-registration"))
     bind(classOf[String]).annotatedWith(named("pushNotificationUrl")).toInstance(baseUrl("push-notification"))

--- a/app/uk/gov/hmrc/pushnotificationscheduler/connectors/GenericConnector.scala
+++ b/app/uk/gov/hmrc/pushnotificationscheduler/connectors/GenericConnector.scala
@@ -33,8 +33,6 @@ trait GenericConnector {
 
   implicit lazy val hc = HeaderCarrier()
 
-  val defaultBatchSize = 10
-
   val externalServiceName = "some-service"
 
   val http: HttpGet with HttpPost with HttpDelete

--- a/app/uk/gov/hmrc/pushnotificationscheduler/connectors/PushNotificationConnector.scala
+++ b/app/uk/gov/hmrc/pushnotificationscheduler/connectors/PushNotificationConnector.scala
@@ -28,14 +28,14 @@ import scala.concurrent.{ExecutionContext, Future}
 trait PushNotificationConnectorApi extends GenericConnector {
   override val externalServiceName: String = "push-notification"
 
-  def getUnsentNotifications(maxBatchSize: Int = defaultBatchSize)(implicit ex: ExecutionContext): Future[Seq[Notification]]
+  def getUnsentNotifications()(implicit ex: ExecutionContext): Future[Seq[Notification]]
   def updateNotifications(notificationStatus: Map[String,NotificationStatus])(implicit ex: ExecutionContext): Future[Response]
 }
 
 @Singleton
 class PushNotificationConnector @Inject()(@Named("pushNotificationUrl") val serviceUrl: String, val http: HttpGet with HttpPost with HttpDelete) extends PushNotificationConnectorApi {
-  override def getUnsentNotifications(maxBatchSize: Int = defaultBatchSize)(implicit ex: ExecutionContext): Future[Seq[Notification]] = {
-    get[Seq[Notification]]("/notifications/unsent", List(("maxBatchSize", maxBatchSize.toString)))
+  override def getUnsentNotifications()(implicit ex: ExecutionContext): Future[Seq[Notification]] = {
+    get[Seq[Notification]]("/notifications/unsent", List.empty[(String, String)])
   }
 
   override def updateNotifications(notificationStatus: Map[String,NotificationStatus])(implicit ex: ExecutionContext): Future[Response] = {

--- a/app/uk/gov/hmrc/pushnotificationscheduler/connectors/PushRegistrationConnector.scala
+++ b/app/uk/gov/hmrc/pushnotificationscheduler/connectors/PushRegistrationConnector.scala
@@ -30,12 +30,12 @@ trait PushRegistrationConnectorApi extends GenericConnector with ServicesConfig 
 
   override val externalServiceName: String = "push-registration"
 
-  def getUnregisteredTokens(maxBatchSize: Int = defaultBatchSize)(implicit ex: ExecutionContext): Future[Seq[RegistrationToken]] = {
-    get[Seq[RegistrationToken]]("/push/endpoint", List(("maxBatchSize", maxBatchSize.toString)))
+  def getUnregisteredTokens()(implicit ex: ExecutionContext): Future[Seq[RegistrationToken]] = {
+    get[Seq[RegistrationToken]]("/push/endpoint", List.empty[(String,String)])
   }
 
-  def recoverFailedRegistrations(maxBatchSize: Int = defaultBatchSize)(implicit ex: ExecutionContext): Future[Seq[RegistrationToken]] = {
-    get[Seq[RegistrationToken]]("/push/endpoint", List(("mode", "recover"), ("maxBatchSize", maxBatchSize.toString)))
+  def recoverFailedRegistrations()(implicit ex: ExecutionContext): Future[Seq[RegistrationToken]] = {
+    get[Seq[RegistrationToken]]("/push/endpoint", List(("mode", "recover")))
   }
 
   def registerEndpoints(tokenToEndpointMap: Map[String,Option[String]])(implicit ex: ExecutionContext): Future[Response] = {

--- a/app/uk/gov/hmrc/pushnotificationscheduler/services/PushNotificationService.scala
+++ b/app/uk/gov/hmrc/pushnotificationscheduler/services/PushNotificationService.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.pushnotificationscheduler.services
 import javax.inject.{Inject, Singleton}
 
 import com.google.inject.ImplementedBy
+import play.api.Logger
 import uk.gov.hmrc.pushnotificationscheduler.connectors.PushNotificationConnectorApi
 import uk.gov.hmrc.pushnotificationscheduler.domain.{Notification, NotificationStatus}
 
@@ -34,7 +35,7 @@ trait PushNotificationServiceApi extends EntityManager {
 }
 
 @Singleton
-class PushNotificationService @Inject() (connector: PushNotificationConnectorApi) extends PushNotificationServiceApi {
+class PushNotificationService @Inject() (connector: PushNotificationConnectorApi, override val logger: Logger) extends PushNotificationServiceApi {
   override def getUnsentNotifications: Future[Seq[Notification]] = fetch[Notification](connector.getUnsentNotifications())
 
   override def updateNotifications(notificationStatus: Map[String, NotificationStatus]): Future[_] =

--- a/app/uk/gov/hmrc/pushnotificationscheduler/services/PushRegistrationService.scala
+++ b/app/uk/gov/hmrc/pushnotificationscheduler/services/PushRegistrationService.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.pushnotificationscheduler.services
 import javax.inject.{Inject, Singleton}
 
 import com.google.inject.ImplementedBy
+import play.api.Logger
 import uk.gov.hmrc.pushnotificationscheduler.connectors.PushRegistrationConnectorApi
 import uk.gov.hmrc.pushnotificationscheduler.domain.RegistrationToken
 
@@ -35,7 +36,7 @@ trait PushRegistrationServiceApi extends EntityManager {
 }
 
 @Singleton
-class PushRegistrationService @Inject() (connector: PushRegistrationConnectorApi) extends PushRegistrationServiceApi {
+class PushRegistrationService @Inject() (connector: PushRegistrationConnectorApi, override val logger: Logger) extends PushRegistrationServiceApi {
   override def getUnregisteredTokens: Future[Seq[RegistrationToken]] = {
     fetch[RegistrationToken](connector.getUnregisteredTokens())
   }

--- a/test/uk/gov/hmrc/pushnotificationscheduler/services/EntityManagerSpec.scala
+++ b/test/uk/gov/hmrc/pushnotificationscheduler/services/EntityManagerSpec.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pushnotificationscheduler.services
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, verifyZeroInteractions, when}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mock.MockitoSugar
+import play.api.Logger
+import uk.gov.hmrc.play.http._
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.pushnotificationscheduler.connectors.{Error, GenericConnector, Response, Success}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future.{failed, successful}
+import scala.concurrent.{ExecutionContext, Future}
+
+class EntityManagerSpec extends UnitSpec with MockitoSugar with ScalaFutures {
+
+  private trait ThingsConnector extends GenericConnector {
+    def getThings()(implicit ex: ExecutionContext): Future[Seq[String]]
+    def updateThings(things: Seq[String])(implicit ex: ExecutionContext): Future[Response]
+  }
+
+  private trait Setup extends MockitoSugar {
+    val mockLogger = mock[org.slf4j.Logger]
+    val mockConnector = mock[ThingsConnector]
+    val stringCaptor = ArgumentCaptor.forClass(classOf[String])
+
+    val service = new EntityManager {
+      override val logger: Logger = new Logger(mockLogger)
+    }
+
+    when(mockLogger.isInfoEnabled).thenReturn(true)
+    when(mockLogger.isWarnEnabled()).thenReturn(true)
+    when(mockLogger.isErrorEnabled()).thenReturn(true)
+
+    val someData = Seq("foo", "bar", "baz")
+  }
+
+  private trait Success extends Setup {
+    when(mockConnector.getThings()(any[ExecutionContext]())).thenReturn(successful(someData))
+    when(mockConnector.updateThings(any[Seq[String]])(any[ExecutionContext]())).thenReturn(successful(Success(200)))
+  }
+
+  private trait NotFound extends Setup {
+    when(mockConnector.getThings()(any[ExecutionContext]())).thenReturn(failed(new HttpException("nothing found", 404)))
+    when(mockConnector.updateThings(any[Seq[String]])(any[ExecutionContext]())).thenReturn(successful(Error(404)))
+  }
+
+  private trait Unavailable extends Setup {
+    when(mockConnector.getThings()(any[ExecutionContext]())).thenReturn(failed(new HttpException("unable to acquire lock", 503)))
+  }
+
+  private trait Failed extends Setup {
+    when(mockConnector.getThings()(any[ExecutionContext]())).thenReturn(failed(Upstream5xxResponse("service failed", 500, 500)))
+    when(mockConnector.updateThings(any[Seq[String]])(any[ExecutionContext]())).thenReturn(failed(Upstream5xxResponse("service failed", 500, 500)))
+  }
+
+  "fetch" should {
+    "not log a message given a 200 response from the downstream service" in new Success {
+
+      await(service.fetch[String](mockConnector.getThings()))
+
+      verifyZeroInteractions(mockLogger)
+    }
+
+    "log an info message given a 404 response from the downstream service" in new NotFound {
+      await(service.fetch[String](mockConnector.getThings()))
+
+      verify(mockLogger).info(stringCaptor.capture())
+
+      val message: String = stringCaptor.getValue
+
+      message shouldBe "No data found"
+    }
+
+    "log a warning given a 503 response from the downstream service" in new Unavailable {
+      await(service.fetch[String](mockConnector.getThings()))
+
+      verify(mockLogger).warn(stringCaptor.capture())
+
+      val message: String = stringCaptor.getValue
+
+      message shouldBe "data service temporarily not available"
+    }
+
+    "log an error given a 500 response from the downstream service" in new Failed {
+      await(service.fetch[String](mockConnector.getThings()))
+
+      verify(mockLogger).error(stringCaptor.capture(), ArgumentMatchers.any[Throwable]())
+
+      val message: String = stringCaptor.getValue
+
+      message shouldBe "Failed to fetch data: service failed"
+    }
+  }
+
+  "update" should {
+    "not log a message when an update was successful" in new Success {
+      await(service.update(mockConnector.updateThings(someData)))
+
+      verifyZeroInteractions(mockLogger)
+    }
+
+    "log an error when an update is not successful" in new NotFound {
+      await(service.update(mockConnector.updateThings(someData)))
+
+      verify(mockLogger).error(stringCaptor.capture())
+
+      val message: String = stringCaptor.getValue
+
+      message shouldBe "Failed to update data, status = 404"
+    }
+
+    "log an error given a downstream service failure" in new Failed {
+      await(service.update(mockConnector.updateThings(someData)))
+
+      verify(mockLogger).error(stringCaptor.capture(), ArgumentMatchers.any[Throwable]())
+
+      val message: String = stringCaptor.getValue
+
+      message shouldBe "Failed to update data: service failed"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pushnotificationscheduler/services/PushNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pushnotificationscheduler/services/PushNotificationServiceSpec.scala
@@ -45,12 +45,12 @@ class PushNotificationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
   }
 
   private trait Success extends Setup {
-    when(connector.getUnsentNotifications(anyInt())(any[ExecutionContext]())).thenReturn(Future.successful(Seq(someNotificationWithoutMessageId, otherNotificationWithMessageId)))
+    when(connector.getUnsentNotifications()(any[ExecutionContext]())).thenReturn(Future.successful(Seq(someNotificationWithoutMessageId, otherNotificationWithMessageId)))
     when(connector.updateNotifications(any[Map[String,NotificationStatus]])(any[ExecutionContext]())).thenReturn(Future.successful(Success(200)))
   }
 
   private trait NotFound extends Setup {
-    when(connector.getUnsentNotifications(anyInt())(any[ExecutionContext]())).thenReturn(Future.failed(new HttpException("there's nothing for you here", 404)))
+    when(connector.getUnsentNotifications()(any[ExecutionContext]())).thenReturn(Future.failed(new HttpException("there's nothing for you here", 404)))
   }
 
   private trait BadRequest extends Setup {
@@ -58,7 +58,7 @@ class PushNotificationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
   }
 
   private trait Failed extends Setup {
-    when(connector.getUnsentNotifications(anyInt())(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
+    when(connector.getUnsentNotifications()(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
     when(connector.updateNotifications(any[Map[String,NotificationStatus]])(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
   }
 

--- a/test/uk/gov/hmrc/pushnotificationscheduler/services/PushRegistrationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pushnotificationscheduler/services/PushRegistrationServiceSpec.scala
@@ -47,7 +47,7 @@ class PushRegistrationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
   "PushRegistrationService.getUnregisteredTokens" should {
 
     "return unregistered tokens when unregistered tokens are available" in new Setup {
-      when(connector.getUnregisteredTokens(anyInt())(any[ExecutionContext]())).thenReturn(Future.successful(expectedTokens))
+      when(connector.getUnregisteredTokens()(any[ExecutionContext]())).thenReturn(Future.successful(expectedTokens))
 
       val result = await(service.getUnregisteredTokens)
 
@@ -55,7 +55,7 @@ class PushRegistrationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
     }
 
     "return an empty list when no unregistered tokens are available" in new Setup {
-      when(connector.getUnregisteredTokens(anyInt())(any[ExecutionContext]())).thenReturn(Future.failed(new HttpException("Move along!", 404)))
+      when(connector.getUnregisteredTokens()(any[ExecutionContext]())).thenReturn(Future.failed(new HttpException("Move along!", 404)))
 
       val result = await(service.getUnregisteredTokens)
 
@@ -63,7 +63,7 @@ class PushRegistrationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
     }
 
     "return an empty list when the push registration service fails" in new Setup {
-      when(connector.getUnregisteredTokens(anyInt())(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
+      when(connector.getUnregisteredTokens()(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
 
       val result = await(service.getUnregisteredTokens)
 
@@ -74,7 +74,7 @@ class PushRegistrationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
   "PushRegistrationService.recoverFailedRegistrations" should {
 
     "return previously failed tokens when such tokens are available" in new Setup {
-      when(connector.recoverFailedRegistrations(anyInt())(any[ExecutionContext]())).thenReturn(Future.successful(expectedTokens))
+      when(connector.recoverFailedRegistrations()(any[ExecutionContext]())).thenReturn(Future.successful(expectedTokens))
 
       val result = await(service.recoverFailedRegistrations)
 
@@ -82,7 +82,7 @@ class PushRegistrationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
     }
 
     "return an empty list when no unregistered tokens are available" in new Setup {
-      when(connector.recoverFailedRegistrations(anyInt())(any[ExecutionContext]())).thenReturn(Future.failed(new HttpException("Move along!", 404)))
+      when(connector.recoverFailedRegistrations()(any[ExecutionContext]())).thenReturn(Future.failed(new HttpException("Move along!", 404)))
 
       val result = await(service.recoverFailedRegistrations)
 
@@ -90,7 +90,7 @@ class PushRegistrationServiceSpec extends UnitSpec with MockitoSugar with ScalaF
     }
 
     "return an empty list when the push registration service fails" in new Setup {
-      when(connector.recoverFailedRegistrations(anyInt())(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
+      when(connector.recoverFailedRegistrations()(any[ExecutionContext]())).thenReturn(Future.failed(Upstream5xxResponse("Kaboom!", 500, 500)))
 
       val result = await(service.recoverFailedRegistrations)
 


### PR DESCRIPTION
Service unavailable (503) from downstream services is treated as a warning, rather than an error.
    
The push-notification and push-registration services will return 503 when they are unable to acquire a mongo lock.
