### PR TITLE
NGC-2474 Fix AbstractMethodError on startup when JSON logger used

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc" %% "microservice-bootstrap" % "6.11.0",
     "uk.gov.hmrc" %% "domain" % "5.0.0",
-    "uk.gov.hmrc" %% "reactive-circuit-breaker" % "3.1.0",
+    "uk.gov.hmrc" %% "reactive-circuit-breaker" % "3.2.0",
     "uk.gov.hmrc" %% "play-scheduling" % "4.1.0"
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
Also bump sbt to 0.13.16 for improved eviction warning messages.